### PR TITLE
Allow numeric types for min and max options of the Range constraint

### DIFF
--- a/Constraint/Constraints/Range.php
+++ b/Constraint/Constraints/Range.php
@@ -64,8 +64,8 @@ class Range extends Constraint
     {
         $resolver
             ->setRequired(['min', 'max'])
-            ->setAllowedTypes('min', ['int'])
-            ->setAllowedTypes('max', ['int'])
+            ->setAllowedTypes('min', ['numeric'])
+            ->setAllowedTypes('max', ['numeric'])
             ->setDefined(['minMessage', 'maxMessage'])
         ;
     }


### PR DESCRIPTION
Fix https://github.com/bjd-php/parsley-bundle/issues/16